### PR TITLE
Fix ADD columns already present

### DIFF
--- a/sql/schema-0.sql
+++ b/sql/schema-0.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS `user` (
   `user_online` tinyint(1) NOT NULL DEFAULT '0',
   `user_enable` tinyint(1) NOT NULL DEFAULT '1',
   `user_2factor` tinyint(1) NOT NULL DEFAULT '1',
-  `user_2factor_scode` varchar(255) COLLATE utf8_unicode_ci NULL,
+  `user_2factor_scode` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
    `user_2factor_paired` tinyint(1) NOT NULL DEFAULT '0',
   `user_start_date` date NOT NULL,
   `user_end_date` date NOT NULL,

--- a/sql/schema-5.sql
+++ b/sql/schema-5.sql
@@ -3,9 +3,6 @@ CREATE TABLE IF NOT EXISTS `application` ( `id` INT(11) AUTO_INCREMENT, `sql_sch
 ALTER TABLE `user` CHANGE `user_start_date` `user_start_date` DATE NULL DEFAULT NULL;
 ALTER TABLE `user` CHANGE `user_end_date` `user_end_date` DATE NULL DEFAULT NULL;
 ALTER TABLE `log` CHANGE `log_end_time` `log_end_time` TIMESTAMP NULL DEFAULT NULL;
---alter table `user` ADD COLUMN `user_2factor` tinyint(1) NOT NULL DEFAULT '1'
---alter table  `user` ADD COLUMN `user_2factor_scode` varchar(255) COLLATE utf8_unicode_ci NULL;
---alter table  `user` ADD COLUMN `user_2factor_paired` tinyint(1) NOT NULL DEFAULT '0';
 UPDATE `user` SET `user_start_date` = NULL WHERE `user_start_date` = '0000-00-00';
 UPDATE `user` SET `user_end_date` = NULL WHERE `user_end_date` = '0000-00-00';
 UPDATE `log` SET `log_end_time` = NULL WHERE `log_end_time` = '0000-00-00';

--- a/sql/schema-5.sql
+++ b/sql/schema-5.sql
@@ -3,9 +3,9 @@ CREATE TABLE IF NOT EXISTS `application` ( `id` INT(11) AUTO_INCREMENT, `sql_sch
 ALTER TABLE `user` CHANGE `user_start_date` `user_start_date` DATE NULL DEFAULT NULL;
 ALTER TABLE `user` CHANGE `user_end_date` `user_end_date` DATE NULL DEFAULT NULL;
 ALTER TABLE `log` CHANGE `log_end_time` `log_end_time` TIMESTAMP NULL DEFAULT NULL;
-alter table `user` ADD COLUMN `user_2factor` tinyint(1) NOT NULL DEFAULT '1'
-alter table  `user` ADD COLUMN `user_2factor_scode` varchar(255) COLLATE utf8_unicode_ci NULL;
-alter table  `user` ADD COLUMN `user_2factor_paired` tinyint(1) NOT NULL DEFAULT '0';
+--alter table `user` ADD COLUMN `user_2factor` tinyint(1) NOT NULL DEFAULT '1'
+--alter table  `user` ADD COLUMN `user_2factor_scode` varchar(255) COLLATE utf8_unicode_ci NULL;
+--alter table  `user` ADD COLUMN `user_2factor_paired` tinyint(1) NOT NULL DEFAULT '0';
 UPDATE `user` SET `user_start_date` = NULL WHERE `user_start_date` = '0000-00-00';
 UPDATE `user` SET `user_end_date` = NULL WHERE `user_end_date` = '0000-00-00';
 UPDATE `log` SET `log_end_time` = NULL WHERE `log_end_time` = '0000-00-00';


### PR DESCRIPTION
Hi, the schema_5 script tries to add columns that are already present. This cause the installation of the DB to fail. I remove the duplicated lines. 